### PR TITLE
0.10.0/dev

### DIFF
--- a/docusaurus/docs/others/data-options.md
+++ b/docusaurus/docs/others/data-options.md
@@ -48,11 +48,19 @@ Following is a list of all the fields possible to be configured in the `dataOpti
 
 #### `ssr`
 * Type: `boolean`
+* Default: `true`
 
 Determines whether the particular data should be fetched during server side rendering or not. Setting this `true` does not affect lazy data.
-`default: true`
+
 
 #### `fetchPolicy`
 * Type: `'cache-first' | 'cache-and-network' | 'network-only'`
+* Default: `'cache-first'`
 
-Determines the how the data is handled. A more detailed explanation can be found in [Caching](./caching.md). `default: 'cache-first'`
+Determines the how the data is handled. A more detailed explanation can be found in [Caching](./caching.md).
+
+#### `prefetch`
+* Type: `boolean`
+* Default: `false`
+
+Determines whether the particular data should be prefetched. Usually used with lazy data. This has no effect when `ssr` is `true`. A more detailed explanation can be found in [Prefetching](../ssr/prefetching.md). 

--- a/docusaurus/docs/ssr/prefetching.md
+++ b/docusaurus/docs/ssr/prefetching.md
@@ -1,0 +1,66 @@
+---
+id: prefetching
+title: Prefetching
+sidebar_label: Prefetching
+---
+
+`react-isomorphic-data` provide helper function to inject `<link rel="prefetch">` tags in to the server-side rendered HTML. This is done to give hints to the browser that the particular resource should be prefetched. Prefetched resources have a very low priority and will only be run when the browser is idle. Prefetching resources could improve performance because when the resource is requested, it might already be ready in the prefetch cache. More about prefetch [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Link_prefetching_FAQ).
+
+In general, you should prefetch data that you think will have a high possibility to be requested by the page.
+
+## Example
+First, make sure you have are setting `dataOptions.prefetch` to true for some of your data. 
+```javascript
+const [fetchData, lazyData] = useLazyData(
+  'http://localhost:3000/some-rest-api/23',
+  {},
+  {},
+  {
+    fetchPolicy: 'cache-first',
+    ssr: false,
+    prefetch: true,
+  },
+);
+```
+
+Then, in your server side rendering code, you can `createPrefetchTags` from the `dataClient` after you have done `renderToStringWithData` or `getDataFromTree`. Finally, put the `prefetchTags` into the `<head>` of your HTML response.
+
+*(shortened example)*
+```javascript
+import { renderToStringWithData, createPrefetchTags } from 'react-isomorphic-data/ssr';
+
+express.get('/*', async (req, res) => {
+  const dataClient = createDataClient({
+    initialCache: {},
+    ssr: true, // set this to true on server side
+  });
+
+  const tree = (
+    <DataProvider client={dataClient}>
+      <App />
+    </DataProvider>
+  );
+
+  let markup;
+
+  try {
+    markup = await renderToStringWithData(tree, dataClient);
+  } catch (err) {
+    console.error('An error happened during server side rendering!');
+  }
+
+  const prefetchTags = createPrefetchTags(dataClient);
+
+  res.send(`
+    <html>
+      <head>${prefetchTags}</head>
+      <body>
+        <div id="root">${markup}</div>
+      </body>
+    </html>
+  `);
+}
+```
+
+## Note
+Setting `prefetch` to `true` for data that are going to be requested during SSR (i. e.: not lazy and has `ssr` set to `true`) can be detrimental. This is because the data would already be ready in the `react-isomorphic-data` cache upon doing [client-side hydration](./client-side-hydration.md), so prefetching it again is an unnecessary extra network request.

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -10,7 +10,7 @@ module.exports = {
     'Getting Started': ['intro', 'examples'],
     Hooks: ['hooks/usedata', 'hooks/uselazydata'],
     'Higher Order Components': ['hocs/withdata', 'hocs/withlazydata'],
-    'Server-side Rendering': ['ssr/intro', 'ssr/rendertostringwithdata', 'ssr/getdatafromtree', 'ssr/client-side-hydration'],
+    'Server-side Rendering': ['ssr/intro', 'ssr/rendertostringwithdata', 'ssr/getdatafromtree', 'ssr/client-side-hydration', 'ssr/prefetching'],
     'Others': ['others/caching', 'others/data-options', 'others/cant-find-answer'],
   },
   // 'react-isomorphic-data': {

--- a/examples/ssr/src/ComponentUsingLazyHOC.tsx
+++ b/examples/ssr/src/ComponentUsingLazyHOC.tsx
@@ -35,5 +35,7 @@ export default withLazyData({
   queryParams: {},
   dataOptions: {
     fetchPolicy: 'cache-first',
+    ssr: false,
+    prefetch: true,
   },
 })(ComponentUsingLazyHOC);

--- a/examples/ssr/src/ComponentUsingLazyHOC.tsx
+++ b/examples/ssr/src/ComponentUsingLazyHOC.tsx
@@ -19,7 +19,7 @@ class ComponentUsingLazyHOC extends React.Component<ComponentUsingLazyHOCProps> 
 
     return (
       <div>
-        This is a ComponentUsingLazyHOC. <button onClick={load}> Click me to load pokemonData</button>
+        This is a ComponentUsingLazyHOC. <button onClick={load}> Click me to load data</button>
         <div>
           <pre>{JSON.stringify(pokemonData, null, 2)}</pre>
         </div>

--- a/examples/ssr/src/Home.tsx
+++ b/examples/ssr/src/Home.tsx
@@ -26,7 +26,10 @@ const ChildComponent = ({ id, ssr }: { id: number; ssr: boolean }) => {
 const Home = () => {
   const eagerData = useData(
     'http://localhost:3000/some-rest-api/1',
-    {},
+    {
+      foo: 'bar',
+      symbols: '!@#$%^&*()////\\\\\\+_+_+_+-==~`'
+    },
     {
       headers: {
         'x-custom-header': 'will only be sent for some-rest-api/1 request',

--- a/examples/ssr/src/server.tsx
+++ b/examples/ssr/src/server.tsx
@@ -75,7 +75,7 @@ server.get('/*', async (req: express.Request, res: express.Response) => {
     console.error('Error while trying to getDataFromTree', err);
   }
 
-  const linkPrefetchTags = createPrefetchTags(dataClient.toBePrefetched);
+  const linkPrefetchTags = createPrefetchTags(dataClient);
   
   res.send(
     `<!doctype html>

--- a/examples/ssr/src/server.tsx
+++ b/examples/ssr/src/server.tsx
@@ -1,7 +1,7 @@
 import express from 'express';
 import React from 'react';
 import { DataProvider, createDataClient } from 'react-isomorphic-data';
-import { renderToStringWithData } from 'react-isomorphic-data/ssr';
+import { renderToStringWithData, createPrefetchTags } from 'react-isomorphic-data/ssr';
 import { StaticRouter } from 'react-router-dom';
 import fetch from 'node-fetch';
 import compression from 'compression';
@@ -74,6 +74,8 @@ server.get('/*', async (req: express.Request, res: express.Response) => {
   } catch (err) {
     console.error('Error while trying to getDataFromTree', err);
   }
+
+  const linkPrefetchTags = createPrefetchTags(dataClient.toBePrefetched);
   
   res.send(
     `<!doctype html>
@@ -83,6 +85,7 @@ server.get('/*', async (req: express.Request, res: express.Response) => {
         <meta charSet='utf-8' />
         <title>Razzle TypeScript</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        ${linkPrefetchTags}
         ${assets.client.css ? `<link rel="stylesheet" href="${assets.client.css}">` : ''}
         <script>
           window.__cache=${JSON.stringify(dataClient.cache)}

--- a/packages/react-isomorphic-data/src/common/Client.ts
+++ b/packages/react-isomorphic-data/src/common/Client.ts
@@ -8,5 +8,6 @@ export const createDataClient = (options: DataClientOptions = {}): DataClient =>
     pendingPromiseFactories: [],
     ssr: ssr || false,
     headers: headers || {},
+    toBePrefetched: {},
   }
 }

--- a/packages/react-isomorphic-data/src/common/Context.ts
+++ b/packages/react-isomorphic-data/src/common/Context.ts
@@ -6,7 +6,8 @@ import { DataContextAPI } from './types';
 
 const DataContext = React.createContext<DataContextAPI>({
   client: createDataClient({}),
-  addToCache: () => {},
+  addToCache: (_key: string, _value: any) => {},
+  addToBePrefetched: (_url: string) => {},
 });
 
 export default DataContext;

--- a/packages/react-isomorphic-data/src/common/Provider.tsx
+++ b/packages/react-isomorphic-data/src/common/Provider.tsx
@@ -11,6 +11,11 @@ interface DataProviderProps {
 
 const DataProvider: React.FC<DataProviderProps> = ({ children, client }) => {
   const [cache, setCache] = React.useState<Record<string, any>>(client.cache);
+  const { toBePrefetched } = client;
+
+  const addToBePrefetched = React.useCallback((url: string) => {
+    toBePrefetched[url] = true;
+  }, [toBePrefetched]);
 
   const addToCache = (key: string, value: any) => {
     if (client.ssr) {
@@ -30,6 +35,7 @@ const DataProvider: React.FC<DataProviderProps> = ({ children, client }) => {
       cache,
     },
     addToCache,
+    addToBePrefetched,
   };
 
   return <DataContext.Provider value={injectedValues}>{children}</DataContext.Provider>;

--- a/packages/react-isomorphic-data/src/common/Provider.tsx
+++ b/packages/react-isomorphic-data/src/common/Provider.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import DataContext from './Context';
-
+import normalisedAddToCache from './utils/addToCache';
 import { DataClient, DataContextAPI } from './types';
 
 interface DataProviderProps {
@@ -14,13 +14,14 @@ const DataProvider: React.FC<DataProviderProps> = ({ children, client }) => {
 
   const addToCache = (key: string, value: any) => {
     if (client.ssr) {
-      client.cache[key] = value;
+      normalisedAddToCache(client.cache, key, value);
     }
 
-    setCache(prevCache => ({
-      ...prevCache,
-      [key]: value,
-    }));
+    setCache(prevCache => {
+      const newCache = { ...prevCache };
+      
+      return normalisedAddToCache(newCache, key, value);
+    });
   };
 
   const injectedValues: DataContextAPI = {

--- a/packages/react-isomorphic-data/src/common/types.ts
+++ b/packages/react-isomorphic-data/src/common/types.ts
@@ -2,6 +2,7 @@
 export interface DataClient {
   cache: Record<string, any>;
   pendingPromiseFactories: { () : Promise<any> }[];
+  toBePrefetched: Record<string, boolean>;
   ssr: boolean;
   headers: Record<string, any>;
 }
@@ -14,5 +15,6 @@ export interface DataClientOptions {
 
 export interface DataContextAPI {
   client: DataClient;
-  addToCache: Function;
+  addToCache: (key: string, value: any) => void;
+  addToBePrefetched: (url: string) => void;
 }

--- a/packages/react-isomorphic-data/src/common/utils/addToCache.ts
+++ b/packages/react-isomorphic-data/src/common/utils/addToCache.ts
@@ -1,0 +1,23 @@
+import getCacheKeys from './getCacheKeys';
+
+const addToCache = (cache: Record<string, any>, url: string, data: Record<string, any>): Record<string, any> => {
+  let temp = cache;
+  const keys = getCacheKeys(url);
+  const lastIndex = keys.length - 1;
+
+  keys.forEach((k, index) => {
+    if (index !== lastIndex) {
+      // not the last key
+      if (!temp[k]) temp[k] = {};
+
+      temp = temp[k];
+    } else {
+      // add the data
+      temp[k] = data;
+    }
+  });
+
+  return cache;
+};
+
+export default addToCache;

--- a/packages/react-isomorphic-data/src/common/utils/getCacheKeys.ts
+++ b/packages/react-isomorphic-data/src/common/utils/getCacheKeys.ts
@@ -1,0 +1,10 @@
+// `http://localhost:3000/some-rest-api/99`;
+// => ["http:", "localhost:3000", "some-rest-api", "99"]
+// `http://localhost:3000/some-rest-api/99?foo=bar&baz=lol`;
+// => ["http:", "localhost:3000", "some-rest-api", "99?foo=bar&baz=lol"]
+
+const getCacheKeys = (url: string): string[] => {
+  return url.split('/').filter(Boolean);
+}
+
+export default getCacheKeys;

--- a/packages/react-isomorphic-data/src/common/utils/retrieveFromCache.ts
+++ b/packages/react-isomorphic-data/src/common/utils/retrieveFromCache.ts
@@ -1,0 +1,18 @@
+import getCacheKeys from './getCacheKeys';
+
+const retrieveFromCache = (cache: Record<string, any>, url: string): any => {
+  let temp = cache;
+
+  const keys = getCacheKeys(url);
+  let tempKey;
+
+  while (tempKey = keys.shift()){
+    if (!temp[tempKey]) return undefined;
+    
+    temp = temp[tempKey];
+  }
+
+  return temp;
+};
+
+export default retrieveFromCache;

--- a/packages/react-isomorphic-data/src/hooks/types.ts
+++ b/packages/react-isomorphic-data/src/hooks/types.ts
@@ -19,4 +19,5 @@ export type LazyDataState = [
 export interface DataHookOptions {
   ssr?: boolean;
   fetchPolicy?: 'cache-first' | 'cache-and-network' | 'network-only';
+  prefetch?: boolean;
 };

--- a/packages/react-isomorphic-data/src/hooks/utils/useBaseData.ts
+++ b/packages/react-isomorphic-data/src/hooks/utils/useBaseData.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { DataContext } from '../../common';
+import retrieveFromCache from '../../common/utils/retrieveFromCache';
 import qsify from '../../utils/querystringify.js';
 
 import { DataHookState, LazyDataState, DataHookOptions } from '../types';
@@ -41,7 +42,7 @@ const useBaseData = (
 
   const queryString = qsify(queryParams, '?');
   const fullUrl = `${url}${queryString}`;
-  const dataFromCache = cache[fullUrl];
+  const dataFromCache = retrieveFromCache(cache, fullUrl);
 
   let initialLoading = lazy ? false : true;
 
@@ -89,7 +90,7 @@ const useBaseData = (
       });
 
   const fetchData = async (): Promise<any> => {
-    if (cache[fullUrl] === undefined) {
+    if (retrieveFromCache(cache, fullUrl) === undefined) {
       setState((prev) => ({ ...prev, loading: true }));
       addToCache(fullUrl, LoadingSymbol); // Use the loading flag as value temporarily
       fetchedFromNetwork.current = true;

--- a/packages/react-isomorphic-data/src/hooks/utils/useBaseData.ts
+++ b/packages/react-isomorphic-data/src/hooks/utils/useBaseData.ts
@@ -19,7 +19,7 @@ const useBaseData = (
   let fetchPolicy = dataOpts.fetchPolicy !== undefined ? dataOpts.fetchPolicy : 'cache-first';
   
   // add `<link rel="prefetch" /> tag for the resource only if it's enabled by user and the query isn't fetched during ssr
-  const shouldPrefetch = dataOpts.prefetch !== undefined ? dataOpts.prefetch && !ssrOpt : false;
+  const shouldPrefetch = dataOpts.prefetch !== undefined ? dataOpts.prefetch && (!ssrOpt || lazy) : false;
 
   const promisePushed = React.useRef<boolean>(false);
   const fetchedFromNetwork = React.useRef<boolean>(false);
@@ -125,6 +125,7 @@ const useBaseData = (
   }
 
   // if the DataClient instance we are using is in ssr mode
+  console.log({ shouldPrefetch, fullUrl });
   if (client.ssr) {
     if (shouldPrefetch) {
       addToBePrefetched(fullUrl);

--- a/packages/react-isomorphic-data/src/hooks/utils/useBaseData.ts
+++ b/packages/react-isomorphic-data/src/hooks/utils/useBaseData.ts
@@ -116,7 +116,7 @@ const useBaseData = (
 
   const memoizedFetchData = React.useCallback(fetchData, [dataFromCache, fullUrl, addToCache]);
   
-  // if this query is supposed to be fetched during SSR
+  // if this data is supposed to be fetched during SSR
   if (isSSR) {
     if (!promisePushed.current && !lazy && !dataFromCache) {
       client.pendingPromiseFactories.push(fetchData);
@@ -125,7 +125,6 @@ const useBaseData = (
   }
 
   // if the DataClient instance we are using is in ssr mode
-  console.log({ shouldPrefetch, fullUrl });
   if (client.ssr) {
     if (shouldPrefetch) {
       addToBePrefetched(fullUrl);

--- a/packages/react-isomorphic-data/src/ssr/createPrefetchTags.ts
+++ b/packages/react-isomorphic-data/src/ssr/createPrefetchTags.ts
@@ -1,7 +1,10 @@
-const createPrefetchTags = (shouldBePrefetched: Record<string, boolean>): string => {
+import { DataClient } from '../common/types';
+
+const createPrefetchTags = (dataClient: DataClient): string => {
+  const { toBePrefetched } = dataClient;
   let output = '';
   
-  Object.keys(shouldBePrefetched).forEach((url: string): void => {
+  Object.keys(toBePrefetched).forEach((url: string): void => {
     output += `<link rel="prefetch" href="${url}" />`;
   });
 

--- a/packages/react-isomorphic-data/src/ssr/createPrefetchTags.ts
+++ b/packages/react-isomorphic-data/src/ssr/createPrefetchTags.ts
@@ -1,0 +1,11 @@
+const createPrefetchTags = (shouldBePrefetched: Record<string, boolean>): string => {
+  let output = '';
+  
+  Object.keys(shouldBePrefetched).forEach((url: string): void => {
+    output += `<link rel="prefetch" href="${url}" />`;
+  });
+
+  return output;
+};
+
+export default createPrefetchTags;

--- a/packages/react-isomorphic-data/src/ssr/index.ts
+++ b/packages/react-isomorphic-data/src/ssr/index.ts
@@ -1,2 +1,3 @@
 export { default as getDataFromTree } from './getDataFromTree';
 export { default as renderToStringWithData } from './renderToStringWithData';
+export { default as createPrefetchTags } from './createPrefetchTags';


### PR DESCRIPTION
Includes:
- [x] #13 Cache normalisation
This make the output of `JSON.stringify(client.cache)` to be smaller
- [x] #9 Support for creating `link prefetch` tags during SSR to fetch resource earlier during browser idle time.
- [x] Update documentation that explains about #9