### PR TITLE
improvement(core): make hoist-non-react-static a peerDep

### DIFF
--- a/examples/ssr/package.json
+++ b/examples/ssr/package.json
@@ -25,6 +25,7 @@
     "body-parser": "^1.19.0",
     "compression": "^1.7.4",
     "express": "^4.17.1",
+    "hoist-non-react-statics": "^3.3.0",
     "node-fetch": "^2.6.0",
     "razzle": "^3.0.0",
     "razzle-plugin-typescript": "^3.0.0",

--- a/packages/react-isomorphic-data/package.json
+++ b/packages/react-isomorphic-data/package.json
@@ -72,6 +72,7 @@
     "typescript": "^3.7.4"
   },
   "peerDependencies": {
+    "hoist-non-react-statics": "^3.3.0",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },

--- a/packages/react-isomorphic-data/rollup.config.js
+++ b/packages/react-isomorphic-data/rollup.config.js
@@ -51,7 +51,7 @@ const mainBundleConfig = {
     { file: pkg.module, format: 'es', sourcemap: true },
   ],
   // Indicate here external modules you don't wanna include in your bundle (i.e.: 'lodash')
-  external: ['react', 'react-dom', 'react-dom/server'],
+  external: ['react', 'react-dom', 'react-dom/server', 'hoist-non-react-statics'],
   watch: {
     include: 'src/**',
   },
@@ -76,7 +76,7 @@ const serverBundleConfig = {
     },
   ],
   // Indicate here external modules you don't wanna include in your bundle (i.e.: 'lodash')
-  external: ['react', 'react-dom', 'react-dom/server'],
+  external: ['react', 'react-dom', 'react-dom/server', 'hoist-non-react-statics'],
   watch: {
     include: 'src/ssr/**',
   },


### PR DESCRIPTION
Solves #42 

As an example, `react-router-dom` has dependency to `hoist-non-react-statics`. Considering how most React app would have dependency `react-router-dom` as well, taking `hoist-non-react-statics` out of the bundle would probably be beneficial.