### PR TITLE
feat(core): raw response support

### DIFF
--- a/docusaurus/docs/others/data-options.md
+++ b/docusaurus/docs/others/data-options.md
@@ -66,6 +66,12 @@ Determines the how the data is handled. A more detailed explanation can be found
 
 Determines whether the data should be fetched or not.
 
+#### `raw`
+* Type: `boolean`
+* Default: `false`
+
+Determines whether to return the `data` as raw response string, or JSON. For example, setting this to `true` will cause the `data` to be a string like `{\"message\":\"Hello world!\"}`.
+
 #### `prefetch`
 * Type: `boolean`
 * Default: `false`

--- a/examples/ssr/src/ComponentUsingHook.tsx
+++ b/examples/ssr/src/ComponentUsingHook.tsx
@@ -3,7 +3,7 @@ import { useData } from 'react-isomorphic-data';
 
 const Comp = () => {
   const { data } = useData(
-    'http://localhost:3000/some-rest-api/24-hook',
+    'http://localhost:3000/some-rest-api/1/24-hook',
     {},
     {}, // options that can be accepted by the native `fetch` API
     {

--- a/examples/ssr/src/Home.tsx
+++ b/examples/ssr/src/Home.tsx
@@ -31,10 +31,6 @@ const Home = () => {
   const eagerData = useData(
     'http://localhost:3000/some-rest-api/1',
     {},
-    // {
-    //   foo: 'bar',
-    //   symbols: '!@#$%^&*()////\\\\\\+_+_+_+-==~`'
-    // },
     {
       headers: {
         'x-custom-header': 'will only be sent for some-rest-api/1 request',
@@ -48,7 +44,10 @@ const Home = () => {
 
   const [fetchData, lazyData] = useLazyData(
     'http://localhost:3000/some-rest-api/2',
-    {},
+    {
+      foo: 'bar',
+      symbols: '!@#$%^&*()////\\\\\\+_+_+_+-==~`'
+    },
     {},
     {
       fetchPolicy: 'network-only',

--- a/examples/ssr/src/Home.tsx
+++ b/examples/ssr/src/Home.tsx
@@ -30,10 +30,11 @@ const Home = () => {
 
   const eagerData = useData(
     'http://localhost:3000/some-rest-api/1',
-    {
-      foo: 'bar',
-      symbols: '!@#$%^&*()////\\\\\\+_+_+_+-==~`'
-    },
+    {},
+    // {
+    //   foo: 'bar',
+    //   symbols: '!@#$%^&*()////\\\\\\+_+_+_+-==~`'
+    // },
     {
       headers: {
         'x-custom-header': 'will only be sent for some-rest-api/1 request',

--- a/examples/ssr/src/routes/Siblings/components/SFCWithHook.tsx
+++ b/examples/ssr/src/routes/Siblings/components/SFCWithHook.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
 import { useData } from 'react-isomorphic-data';
 
-const SFCWithHook: React.SFC<{ id: number }> = ({ id }) => {
+const SFCWithHook: React.SFC<{ id: number; raw?: boolean }> = ({
+  id,
+  raw = false,
+}) => {
   const { data, loading, refetch } = useData(
     `http://localhost:3000/some-rest-api/8-24-siblings-${id}`,
     {},
@@ -10,15 +13,19 @@ const SFCWithHook: React.SFC<{ id: number }> = ({ id }) => {
       // additional options
       ssr: true,
       fetchPolicy: 'cache-first',
+      raw,
     },
   );
 
-  console.log({ id, data, loading });
+  console.log({ id, data, loading, raw });
 
   return (
     <>
-      <h1>SFCWithHook, id: {id} <button onClick={refetch}>Refetch</button></h1>
-      {data ? data.randomNumber : 'loading...'}
+      <h1>
+        SFCWithHook, id: {id} raw: {String(raw)}{' '}
+        <button onClick={refetch}>Refetch</button>
+      </h1>
+      {data ? (raw ? data : data.randomNumber) : 'loading...'}
       {String(loading)}
     </>
   );

--- a/examples/ssr/src/routes/Siblings/views/main.tsx
+++ b/examples/ssr/src/routes/Siblings/views/main.tsx
@@ -5,9 +5,10 @@ const SiblingsMainView: React.SFC = () => {
   return (
     <>
       <SFCWithHook id={1} />
+      <SFCWithHook id={1} />
+      <SFCWithHook id={1} raw />
       <SFCWithHook id={2} />
       <SFCWithHook id={3} />
-      <SFCWithHook id={1} />
     </>
   );
 };

--- a/examples/ssr/src/server.tsx
+++ b/examples/ssr/src/server.tsx
@@ -99,7 +99,7 @@ server.get('/*', async (req: express.Request, res: express.Response) => {
   // pass the same dataClient instance you are passing to your provider here
   try {
     const start = process.hrtime();
-    markup = await renderToStringWithData(reactApp, dataClient);
+    markup = await renderToStringWithData(reactApp);;
     time.push(process.hrtime(start));
 
     getResult();

--- a/examples/ssr/src/server.tsx
+++ b/examples/ssr/src/server.tsx
@@ -99,7 +99,7 @@ server.get('/*', async (req: express.Request, res: express.Response) => {
   // pass the same dataClient instance you are passing to your provider here
   try {
     const start = process.hrtime();
-    markup = await renderToStringWithData(reactApp);;
+    markup = await renderToStringWithData(reactApp);
     time.push(process.hrtime(start));
 
     getResult();

--- a/packages/react-isomorphic-data/src/common/__tests__/preloadData.raw.test.ts
+++ b/packages/react-isomorphic-data/src/common/__tests__/preloadData.raw.test.ts
@@ -16,9 +16,9 @@ describe('preloadData tests', () => {
   it('Should throw a promise when data is not ready yet', async () => {
     fetchMock.mockResponse(JSON.stringify({ message: 'Hello world!' }));
     const client = createDataClient({ ssr: false });
-    const url = 'http://localhost:3000/some-rest-api';
+    const url = 'http://localhost:3000/some-rest-api-raw';
 
-    const resource = preloadData(client, url);
+    const resource = preloadData(client, url, {}, {}, { raw: true });
 
     expect(resource.read).toThrow();
     
@@ -27,16 +27,17 @@ describe('preloadData tests', () => {
     } catch (promise) {
       await promise;
       
-      expect(resource.read()).toStrictEqual({ message: 'Hello world!' });
+      expect(resource.read()).toStrictEqual('{\"message\":\"Hello world!\"}');
     }
   });
 
   it('Should throw an error the fetch is rejected', async () => {
     fetchMock.mockReject(() => Promise.reject('Fabricated error'));
-    const client = createDataClient({ ssr: false });
-    const url = 'http://localhost:3000/some-rest-api/2';
 
-    const resource = preloadData(client, url);
+    const client = createDataClient({ ssr: false });
+    const url = 'http://localhost:3000/some-rest-api-raw/2';
+
+    const resource = preloadData(client, url, {}, undefined, { raw: true });
 
     expect(resource.read).toThrow();
     
@@ -45,16 +46,17 @@ describe('preloadData tests', () => {
     } catch (promise) {
       await promise;
      
-      expect(resource.read).toThrowError();
+      expect(resource.read).toThrow();
+      expect(true).toBe(true);
     }
   });
 
   it('Should use data from cache if available', async () => {
     fetchMock.mockResponse(JSON.stringify({ message: 'Hello world!' }));
     const client = createDataClient({ ssr: false });
-    const url = 'http://localhost:3000/some-rest-api/3';
+    const url = 'http://localhost:3000/some-rest-api-raw/3';
 
-    const resource = preloadData(client, url);
+    const resource = preloadData(client, url, {}, {}, { raw: true });
 
     expect(resource.read).toThrow();
      
@@ -63,9 +65,9 @@ describe('preloadData tests', () => {
     } catch (promise) {
       await promise;
      
-      expect(resource.read()).toStrictEqual({ message: 'Hello world!' });
+      expect(resource.read()).toStrictEqual('{\"message\":\"Hello world!\"}');
 
-      const resource2 = preloadData(client, url);
+      const resource2 = preloadData(client, url, {}, {}, { raw: true });
 
       expect(resource2.read()).toStrictEqual(resource.read());
     }
@@ -75,10 +77,11 @@ describe('preloadData tests', () => {
     fetchMock.mockResponse(JSON.stringify({ message: 'Hello world!' }));
     const fabricatedError = new Error('Fabricated error');
     const client = createDataClient({ ssr: false });
-    const url = 'http://localhost:3000/some-rest-api/4';
+    const url = 'http://localhost:3000/some-rest-api-raw/4';
 
     const resource = preloadData(client, url, {}, {}, {
       fetchPolicy: 'network-only',
+      raw: true,
     });
 
     expect(resource.read).toThrow();
@@ -90,7 +93,7 @@ describe('preloadData tests', () => {
     } catch (promise) {
       await promise;
       
-      expect(resource.read()).toStrictEqual({ message: 'Hello world!' });
+      expect(resource.read()).toStrictEqual('{\"message\":\"Hello world!\"}');
       
       const resource2 = preloadData(client, url);
       

--- a/packages/react-isomorphic-data/src/common/utils/addToCache.ts
+++ b/packages/react-isomorphic-data/src/common/utils/addToCache.ts
@@ -13,7 +13,8 @@ const addToCache = (cache: Record<string, any>, url: string, data: Record<string
       temp = temp[k];
     } else {
       // add the data
-      temp[k] = data;
+      temp[k] = temp[k] || {};
+      temp[k].__raw = data;
     }
   });
 

--- a/packages/react-isomorphic-data/src/common/utils/retrieveFromCache.ts
+++ b/packages/react-isomorphic-data/src/common/utils/retrieveFromCache.ts
@@ -12,7 +12,7 @@ const retrieveFromCache = (cache: Record<string, any>, url: string): any => {
     temp = temp[tempKey];
   }
 
-  return temp;
+  return temp.__raw;
 };
 
 export default retrieveFromCache;

--- a/packages/react-isomorphic-data/src/hooks/__tests__/useData.raw.test.tsx
+++ b/packages/react-isomorphic-data/src/hooks/__tests__/useData.raw.test.tsx
@@ -82,15 +82,13 @@ describe('useData hook tests', () => {
       </DataProvider>
     );
 
-    const { findByText, debug } = render(App);
+    const { findByText } = render(App);
 
     expect(await findByText('loading...')).toBeDefined();
 
     await wait();
 
     expect(await findByText('{\"message\":\"Hello world!\"}')).toBeDefined();
-
-    debug();
   });
 
   it('should throw an error when not wrapped with DataProvider', async () => {

--- a/packages/react-isomorphic-data/src/hooks/__tests__/useData.raw.test.tsx
+++ b/packages/react-isomorphic-data/src/hooks/__tests__/useData.raw.test.tsx
@@ -1,0 +1,134 @@
+import * as React from 'react';
+import { FetchMock } from 'jest-fetch-mock';
+import { render, wait } from '@testing-library/react';
+import { createDataClient, DataProvider } from '../../common';
+import useData from '../useData';
+
+const fetchMock = fetch as FetchMock;
+
+describe('useData hook tests', () => {
+  const onError = (e: Event) => {
+    e.preventDefault();
+  };
+
+  beforeEach(() => {
+    // to suppress error logs from error boundaries
+    // https://github.com/facebook/react/issues/11098#issuecomment-412682721
+    window.addEventListener('error', onError);
+    fetchMock.resetMocks();
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    window.removeEventListener('error', onError);
+    jest.useRealTimers();
+  });
+
+  it('should fetch data correctly', async () => {
+    fetchMock.mockResponse(JSON.stringify({ message: 'Hello world!' }));
+
+    const client = createDataClient();
+
+    const Comp = () => {
+      const { data, loading } = useData(
+        'http://localhost/somewhere',
+        {},
+        {},
+        { skip: false, ssr: true, raw: true },
+      );
+
+      return loading || !data ? (
+        <div>loading...</div>
+      ) : (
+        <div>{data}</div>
+      );
+    };
+    const App = (
+      <DataProvider client={client}>
+        <Comp />
+      </DataProvider>
+    );
+
+    const { findByText } = render(App);
+
+    expect(await findByText('loading...')).toBeDefined();
+
+    await wait();
+
+    expect(await findByText('{\"message\":\"Hello world!\"}')).toBeDefined();
+  });
+
+  it('should fetch data correctly; fetchPolicy: "network-only"', async () => {
+    fetchMock.mockResponse(JSON.stringify({ message: 'Hello world!' }));
+
+    const client = createDataClient();
+
+    const Comp = () => {
+      const { data, loading } = useData(
+        'http://localhost/somewhere',
+        {},
+        {},
+        { skip: false, ssr: true, fetchPolicy: 'network-only', raw: true },
+      );
+
+      return loading || !data ? (
+        <div>loading...</div>
+      ) : (
+        <div>{data}</div>
+      );
+    };
+    const App = (
+      <DataProvider client={client}>
+        <Comp />
+      </DataProvider>
+    );
+
+    const { findByText, debug } = render(App);
+
+    expect(await findByText('loading...')).toBeDefined();
+
+    await wait();
+
+    expect(await findByText('{\"message\":\"Hello world!\"}')).toBeDefined();
+
+    debug();
+  });
+
+  it('should throw an error when not wrapped with DataProvider', async () => {
+    fetchMock.mockResponse(JSON.stringify({ message: 'Hello world!' }));
+
+    class ErrorBoundary extends React.Component {
+      state = { error: false, errorObject: null };
+
+      static getDerivedStateFromError(error: Error) {
+        return { error: true, errorObject: error };
+      }
+
+      render() {
+        return !this.state.error ? (
+          this.props.children
+        ) : (
+          <div>Error happened!</div>
+        );
+      }
+    }
+
+    const Comp = () => {
+      const { data, loading } = useData('http://localhost/somewhere');
+
+      return loading || !data ? (
+        <div>loading...</div>
+      ) : (
+        <div>{data}</div>
+      );
+    };
+    const App = (
+      <ErrorBoundary>
+        <Comp />
+      </ErrorBoundary>
+    );
+
+    const { findByText } = render(App);
+
+    expect(await findByText('Error happened!')).toBeDefined();
+  });
+});

--- a/packages/react-isomorphic-data/src/hooks/types.ts
+++ b/packages/react-isomorphic-data/src/hooks/types.ts
@@ -21,4 +21,5 @@ export interface DataHookOptions {
   fetchPolicy?: 'cache-first' | 'cache-and-network' | 'network-only';
   prefetch?: boolean;
   skip?: boolean;
+  raw?: boolean;
 };

--- a/packages/react-isomorphic-data/src/hooks/utils/useBaseData.ts
+++ b/packages/react-isomorphic-data/src/hooks/utils/useBaseData.ts
@@ -6,6 +6,8 @@ import { LazyDataState, DataHookOptions } from '../types';
 import useFetchRequirements from './useFetchRequirements';
 import useCacheSubscription, { LoadingSymbol } from './useCacheSubscription';
 
+const simpleCache: Record<string, any> = {};
+
 const useBaseData = <T, > (
   url: string,
   queryParams: Record<string, any> = {},
@@ -18,6 +20,7 @@ const useBaseData = <T, > (
   
   const ssrOpt = dataOpts.ssr !== undefined ? dataOpts.ssr : true;
   const skip = dataOpts.skip !== undefined ? dataOpts.skip : false;
+  const raw = dataOpts.raw !== undefined ? dataOpts.raw : false;
   
   const { 
     client,
@@ -43,8 +46,8 @@ const useBaseData = <T, > (
 
   const createFetch = React.useCallback(() => {
     promiseRef.current = fetcher(fullUrl, finalFetchOpts)
-      .then((result) => result.json())
-      .then((json) => {
+      .then((result) => result.text())
+      .then((data) => {
         // this block of code will cause 2 re-renders because React doesn't batch these 2 updates
         // https://twitter.com/dan_abramov/status/887963264335872000?lang=en
         // For React 16.x we can use `unstable_batchedUpdates()` to solve this
@@ -52,7 +55,7 @@ const useBaseData = <T, > (
           if (!useTempData) {
             // only cache response for GET requests
             // AND non 'network-only' requests
-            addToCache(fullUrl, json);
+            addToCache(fullUrl, data);
           } else {
             // resets the cache to 'undefined'
             addToCache(fullUrl, undefined);
@@ -61,13 +64,13 @@ const useBaseData = <T, > (
           if (!isSSR) {
             setState((prev: any) => ({
               ...prev,
-              tempCache: { ...prev.tempCache, [fullUrl]: json },
+              tempCache: { ...prev.tempCache, [fullUrl]: data },
               error: { ...prev.error, [fullUrl]: undefined },
             }));
           }
         });
 
-        return json;
+        return data;
       })
       .catch((err) => {
         if (!isSSR) {
@@ -154,16 +157,40 @@ const useBaseData = <T, > (
     }
   }, [skip, lazy, memoizedFetchData, dataFromCache, state.error, fullUrl]);
 
+  const isLoading = dataFromCache === LoadingSymbol || (client.ssr && typeof dataFromCache === 'undefined' && !lazy);
+  
   const finalData = dataFromCache !== LoadingSymbol ? dataFromCache : null;
   const usedData = (!useTempData ? finalData : state.tempCache[fullUrl]) || null;
-  const isLoading = dataFromCache === LoadingSymbol || (client.ssr && typeof dataFromCache === 'undefined' && !lazy);
+  const memoizedData = React.useMemo(() => {
+    /**
+     * we only store the raw response string in the cache to avoid including double the amount of data
+     * for the client.cache rehydration on client side
+     * The caveats are: 
+     * 1. each hooks will need to do JSON.parse again to get the JSON
+     *    So, we do some simple caching here to improve this
+     * 2. Every re-renders means another string comparison
+     *    Seems like string comparison isn't that expensive, even with long strings.
+     *    So, let's settle with this for now
+     *    (https://jsperf.com/eqaulity-is-constant-time)
+     */
+
+    if (raw) {
+      // if we just want the raw data, just return it immediately
+      return usedData;
+    } else {
+      // else, we want the data in json form
+      simpleCache[usedData] = JSON.parse(usedData);
+
+      return simpleCache[usedData];
+    }
+  }, [usedData, raw]);
 
   return [
     memoizedFetchData,
     {
       error: state.error?.[fullUrl] || null,
       loading: isLoading,
-      data: usedData,
+      data: memoizedData,
       refetch: () => {
         // always reset cache on refetch
         addToCache(fullUrl, LoadingSymbol); // Use the loading flag as value temporarily

--- a/packages/react-isomorphic-data/src/hooks/utils/useBaseData.ts
+++ b/packages/react-isomorphic-data/src/hooks/utils/useBaseData.ts
@@ -179,7 +179,9 @@ const useBaseData = <T, > (
       return usedData;
     } else {
       // else, we want the data in json form
-      simpleCache[usedData] = JSON.parse(usedData);
+      if (!simpleCache[usedData]) {
+        simpleCache[usedData] = JSON.parse(usedData);
+      }
 
       return simpleCache[usedData];
     }

--- a/packages/react-isomorphic-data/src/ssr/__tests__/renderToStringWithData.test.tsx
+++ b/packages/react-isomorphic-data/src/ssr/__tests__/renderToStringWithData.test.tsx
@@ -36,7 +36,7 @@ describe('Server-side rendering utilities test', () => {
 
     await getDataFromTree(App);
 
-    expect(retrieveFromCache(client.cache, url)).toStrictEqual({ message: 'Hello world!' });
+    expect(retrieveFromCache(client.cache, url)).toStrictEqual("{\"message\":\"Hello world!\"}");
   });
 
   it('Should render a HTML markup with fetched data correctly', async () => {


### PR DESCRIPTION
#50 

### Feature
We now have a new DataOptions, `raw?: boolean` defaults to `false`.

With this PR:
1. We now only store the raw response string in `DataClient.cache`
2. Each hooks will call `JSON.parse` if `DataOptions.raw === false` (the default is `false`). There is also a simple caching mechanism to avoid calling JSON.parse repeatedly.
3. If `DataOptions.raw === true`, we simply return the stored raw response string

### Bug Fix
Change the cache data structure to avoid collision with nested URL paths

<img width="369" alt="Screen Shot 2020-03-28 at 16 35 12" src="https://user-images.githubusercontent.com/7252454/77820066-1f7f2e00-7112-11ea-8434-32aec8b32619.png">
