### PR TITLE
Ability to set global fetch policy & implement ssrForceFetchDelay

### DIFF
--- a/packages/react-isomorphic-data/src/common/Client.ts
+++ b/packages/react-isomorphic-data/src/common/Client.ts
@@ -4,12 +4,14 @@ import { DataClient, DataClientOptions } from './types';
 export const createDataClient = (
   options: DataClientOptions = {},
 ): DataClient => {
-  const { ssr, initialCache, headers, test } = options;
+  const { ssr, initialCache, headers, test, ssrForceFetchDelay } = options;
   const subscribers: Record<string, Map<Function, Function>> = {};
 
   return {
     cache: initialCache ? { ...initialCache } : {},
     ssr: ssr || false,
+    ssrForceFetchDelay: ssrForceFetchDelay || 0,
+    ssrForceFetchDelayTimer: Date.now(),
     test: test || false,
     headers: headers || {},
     toBePrefetched: {},

--- a/packages/react-isomorphic-data/src/common/__tests__/Client.test.tsx
+++ b/packages/react-isomorphic-data/src/common/__tests__/Client.test.tsx
@@ -11,6 +11,7 @@ describe('DataClient', () => {
 
     expect(client.ssr).toBe(true);
     expect(client.headers['x-header']).toBe('custom header');
+    expect(client.ssrForceFetchDelay).toBe(0);
   })
   test('DataClient can be created on non-SSR mode without initialCache', async () => {
     const client = createDataClient({ ssr: false });
@@ -24,6 +25,12 @@ describe('DataClient', () => {
     expect(client.ssr).toBe(false);
     expect(Object.keys(client.cache).length).toBe(1);
     expect(client.cache.foo).toBe('bar');
+  })
+
+  test('DataClient can be allow to set force fetch delay', async () => {
+    const client = createDataClient({ ssr: false, ssrForceFetchDelay: 200 });
+
+    expect(client.ssrForceFetchDelay).toBe(200);
   })
 
   test('DataClient subscription model works properly', async () => {

--- a/packages/react-isomorphic-data/src/common/types.ts
+++ b/packages/react-isomorphic-data/src/common/types.ts
@@ -5,6 +5,9 @@ export interface DataClient {
   cache: Record<string, any>;
   toBePrefetched: Record<string, boolean>;
   ssr: boolean;
+  ssrForceFetchDelay: number;
+  ssrForceFetchDelayTimer: number;
+  fetchPolicy?: string;
   test: boolean;
   headers: Record<string, any>;
   addSubscriber: (key: string, callback: Function) => void;
@@ -14,6 +17,8 @@ export interface DataClient {
 
 export interface DataClientOptions {
   ssr?: boolean;
+  ssrForceFetchDelay?: number;
+  fetchPolicy?: string;
   test?: boolean;
   initialCache?: Record<string, any>;
   headers?: Record<string, any>;

--- a/packages/react-isomorphic-data/src/common/utils/createFetchRequirements.ts
+++ b/packages/react-isomorphic-data/src/common/utils/createFetchRequirements.ts
@@ -9,7 +9,14 @@ const createFetchOptions = (
   lazy = false,
 ): [RequestInit, string] => {
   const finalMethod = fetchOptions.method && lazy ? fetchOptions.method : 'GET';
-  let fetchPolicy = dataOpts.fetchPolicy !== undefined ? dataOpts.fetchPolicy : 'cache-first';
+
+  let fetchPolicy = 'cache-first';
+  if (dataOpts.fetchPolicy !== undefined) {
+    fetchPolicy = dataOpts.fetchPolicy;
+  } else if (client.fetchPolicy !== undefined) {
+    fetchPolicy = client.fetchPolicy;
+  }
+
   const ssrOpt = dataOpts.ssr !== undefined ? dataOpts.ssr : true;
   const isSSR = client.ssr && ssrOpt && typeof window === 'undefined';
 

--- a/packages/react-isomorphic-data/src/hooks/utils/useBaseData.ts
+++ b/packages/react-isomorphic-data/src/hooks/utils/useBaseData.ts
@@ -108,7 +108,7 @@ const useBaseData = <T, > (
     const currentDataInCache = retrieveFromCache(fullUrl);
 
     // data not in cache yet
-    if (currentDataInCache === undefined && !state.tempCache[fullUrl])
+    if (currentDataInCache === undefined && !state.tempCache[fullUrl]) {
       addToCache(fullUrl, LoadingSymbol); // Use the loading flag as value temporarily
 
       fetchedFromNetwork.current = true;


### PR DESCRIPTION
1. fetch policy is first read from current useData, if it is present,
we use it. If it is not present, we check for policy in global client
if that is also not present, we got for default cache-first Fixed #55

2. ssrForceFetchDelay timer starts when data client is created, during
render we again take new time, see the diff and decide to use from
cache or to be make a netowork. Fixed #14 

3. Support for it in HOC yet to be addded, example yet to be updated
and tests needs to be updated - (pending task)
